### PR TITLE
Make sure data is available for finding exchange rates

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -144,11 +144,17 @@ def get_base_band(level=None):
             return get_base_band()
     else:
         try:
-            default_level = models.SupportLevel.objects.get(default=True)
-            return models.Band.objects.filter(
-                base=True,
-                level=default_level,
-            ).latest()
+            default_level = utils.get_standard_support_level()
+            if default_level:
+                return models.Band.objects.filter(
+                    base=True,
+                    level=default_level,
+                ).latest()
+            else:
+                return models.Band.objects.filter(
+                    base=True,
+                ).latest()
+
         except models.Band.DoesNotExist:
             logger.warning('No default base band found.')
 

--- a/logic.py
+++ b/logic.py
@@ -144,11 +144,13 @@ def get_base_band(level=None):
             return get_base_band()
     else:
         try:
+            default_level = models.SupportLevel.objects.get(default=True)
             return models.Band.objects.filter(
-                base=True
+                base=True,
+                level=default_level,
             ).latest()
         except models.Band.DoesNotExist:
-            logger.warning('No base band found')
+            logger.warning('No default base band found.')
 
 
 def latest_multiplier_for_indicator(

--- a/logic.py
+++ b/logic.py
@@ -256,10 +256,6 @@ def keep_default_unique(obj):
     :obj: an unsaved model instance with a property named 'default'
     """
     if obj.default:
-        try:
-            other = type(obj).objects.get(default=True)
-            if obj != other:
-                other.default = False
-                other.save()
-        except type(obj).DoesNotExist:
-            pass
+        type(obj).objects.filter(default=True).exclude(pk=obj.pk).update(
+            default=False,
+        )

--- a/models.py
+++ b/models.py
@@ -197,7 +197,7 @@ class Currency(models.Model):
             base_band = logic.get_base_band()
 
         if base_band:
-            base_key = base_band.country.alpha3
+            base_key = base_band.currency.region
         else:
             # This is needed during initial configuration
             base_key = '---'

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -61,7 +61,11 @@ class LogicTests(test_models.TestCaseWithData):
 
         base_bands = logic.get_base_bands()
         self.assertListEqual(
-            [self.band_base_level_other, self.band_base],
+            [
+                self.band_base_country_other,
+                self.band_base_level_other,
+                self.band_base
+            ],
             base_bands,
         )
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -44,17 +44,42 @@ class LogicTests(test_models.TestCaseWithData):
             data = logic.get_indicator_by_country(self.fake_indicator, 2050)
             self.assertEqual(data['NLD'], 12345)
 
-    def test_get_base_band(self):
-
+    def test_get_base_band_base_level(self):
         base_band = logic.get_base_band(self.level_base)
         self.assertEqual(
             self.band_base,
             base_band,
         )
+
+    def test_get_base_band_other_level(self):
         other_base_band = logic.get_base_band(self.level_other)
         self.assertEqual(
             self.band_base_level_other,
             other_base_band,
+        )
+
+    def test_get_base_band_no_args(self):
+        base_band = logic.get_base_band()
+        self.assertEqual(
+            self.band_base,
+            base_band,
+        )
+
+    def test_get_base_band_no_args_no_default_level(self):
+
+        # Make it so there is no default level
+        self.level_base.default = False
+        self.level_base.save()
+
+        base_band = logic.get_base_band()
+
+        # Restore data
+        self.level_base.default = True
+        self.level_base.save()
+
+        self.assertEqual(
+            self.band_base,
+            base_band,
         )
 
     def test_get_base_bands(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 
 from plugins.consortial_billing import models, plugin_settings
+from plugins.consortial_billing import utils
 from utils.testing import helpers
 from press import models as press_models
 from cms.models import Page
@@ -243,36 +244,28 @@ class ModelTests(TestCaseWithData):
     @patch('plugins.consortial_billing.logic.latest_multiplier_for_indicator')
     def test_currency_exchange_rate_with_typical_args(self, latest_multiplier):
         self.currency_base.exchange_rate(base_band=self.band_base_country_other)
-        self.assertIn(
+        expected_args = (
             plugin_settings.RATE_INDICATOR,
-            latest_multiplier.call_args.args,
+            self.currency_base.region,  # Target currency
+            self.currency_other.region, # Specified base currency
+            utils.setting('missing_data_exchange_rate')
         )
-        # Target currency
-        self.assertIn(
-            self.currency_base.region,
-            latest_multiplier.call_args.args,
-        )
-        # Base currency generated with specified base band
-        self.assertIn(
-            self.currency_other.region,
+        self.assertTupleEqual(
+            expected_args,
             latest_multiplier.call_args.args,
         )
 
     @patch('plugins.consortial_billing.logic.latest_multiplier_for_indicator')
     def test_currency_exchange_rate_with_no_args(self, latest_multiplier):
         self.currency_other.exchange_rate()
-        self.assertIn(
+        expected_args = (
             plugin_settings.RATE_INDICATOR,
-            latest_multiplier.call_args.args,
+            self.currency_other.region,  # Target currency
+            self.currency_base.region, # Default base currency
+            utils.setting('missing_data_exchange_rate')
         )
-        # Target currency
-        self.assertIn(
-            self.currency_other.region,
-            latest_multiplier.call_args.args,
-        )
-        # Base currency generated with default base band
-        self.assertIn(
-            self.currency_other.region,
+        self.assertTupleEqual(
+            expected_args,
             latest_multiplier.call_args.args,
         )
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -52,7 +52,11 @@ class ViewTests(test_models.TestCaseWithData):
             response.context['plugin'],
         )
         self.assertListEqual(
-            [self.band_base_level_other, self.band_base],
+            [
+                self.band_base_country_other,
+                self.band_base_level_other,
+                self.band_base
+            ],
             response.context['base_bands'],
         )
         self.assertEqual(

--- a/utils.py
+++ b/utils.py
@@ -170,6 +170,12 @@ def get_standard_support_level():
     try:
         return models.SupportLevel.objects.get(default=True)
     except models.SupportLevel.DoesNotExist:
+        logger.error(
+            'No default support level found. '
+            'Using the support level ordered last, '
+            'but that may produce unintended results. '
+            'For best results, set a level as the default.'
+        )
         return models.SupportLevel.objects.all().last()
 
 


### PR DESCRIPTION
These changes implement currency region not country as the basis of exchange rates. This was planned but not yet implemented. It doesn't change resulting rates, it just moves from a deprecated source to a more trustworthy one.

Closes #56